### PR TITLE
reduce test time by waiting for conditions

### DIFF
--- a/moveit_ros/moveit_servo/src/collision_check.cpp
+++ b/moveit_ros/moveit_servo/src/collision_check.cpp
@@ -202,7 +202,7 @@ void CollisionCheck::run()
   // publish message
   {
     auto msg = std::make_unique<std_msgs::msg::Float64>();
-    msg.get()->data = velocity_scale_;
+    msg->data = velocity_scale_;
     collision_velocity_scale_pub_->publish(std::move(msg));
   }
 }
@@ -218,7 +218,7 @@ void CollisionCheck::printCollisionPairs(collision_detection::CollisionResult::C
                                     << contact_map.begin()->first.first << ", " << contact_map.begin()->first.second);
     // Log all other contacts if in debug mode
     RCLCPP_DEBUG_STREAM_THROTTLE(LOGGER, clock, ROS_LOG_THROTTLE_PERIOD, "Objects in collision:");
-    for (auto contact : contact_map)
+    for (const auto& contact : contact_map)
     {
       RCLCPP_DEBUG_STREAM_THROTTLE(LOGGER, clock, ROS_LOG_THROTTLE_PERIOD, "\t" << contact.first.first << ", "
                                                                                 << contact.first.second);

--- a/moveit_ros/moveit_servo/src/low_pass_filter.cpp
+++ b/moveit_ros/moveit_servo/src/low_pass_filter.cpp
@@ -46,7 +46,6 @@ namespace moveit_servo
 {
 namespace
 {
-constexpr char LOGNAME[] = "low_pass_filter";
 constexpr double EPSILON = 1e-9;
 }
 

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -232,7 +232,7 @@ void ServoCalcs::run()
 {
   // Publish status each loop iteration
   auto status_msg = std::make_unique<std_msgs::msg::Int8>();
-  status_msg.get()->data = static_cast<int8_t>(status_);
+  status_msg->data = static_cast<int8_t>(status_);
   status_pub_->publish(std::move(status_msg));
 
   // After we publish, status, reset it back to no warnings
@@ -324,7 +324,7 @@ void ServoCalcs::run()
   {
     // Joint trajectory is not populated with anything, so set it to the last positions and 0 velocity
     *joint_trajectory = *last_sent_command_;
-    for (auto& point : joint_trajectory.get()->points)
+    for (auto& point : joint_trajectory->points)
     {
       point.velocities.assign(point.velocities.size(), 0);
     }
@@ -379,7 +379,7 @@ void ServoCalcs::run()
     // (trajectory_msgs/JointTrajectory or std_msgs/Float64MultiArray).
     if (parameters_->command_out_type == "trajectory_msgs/JointTrajectory")
     {
-      joint_trajectory.get()->header.stamp = node_->now();
+      joint_trajectory->header.stamp = node_->now();
       *last_sent_command_ = *joint_trajectory;
       trajectory_outgoing_cmd_pub_->publish(std::move(joint_trajectory));
     }
@@ -387,9 +387,9 @@ void ServoCalcs::run()
     {
       auto joints = std::make_unique<std_msgs::msg::Float64MultiArray>();
       if (parameters_->publish_joint_positions && !joint_trajectory->points.empty())
-        joints.get()->data = joint_trajectory.get()->points[0].positions;
-      else if (parameters_->publish_joint_velocities && !joint_trajectory.get()->points.empty())
-        joints.get()->data = joint_trajectory.get()->points[0].velocities;
+        joints->data = joint_trajectory->points[0].positions;
+      else if (parameters_->publish_joint_velocities && !joint_trajectory->points.empty())
+        joints->data = joint_trajectory->points[0].velocities;
       *last_sent_command_ = *joint_trajectory;
       multiarray_outgoing_cmd_pub_->publish(std::move(joints));
     }
@@ -909,7 +909,7 @@ bool ServoCalcs::calculateWorstCaseStopTime()
   // publish message
   {
     auto msg = std::make_unique<std_msgs::msg::Float64>();
-    msg.get()->data = worst_case_stop_time;
+    msg->data = worst_case_stop_time;
     worst_case_stop_time_pub_->publish(std::move(msg));
   }
 
@@ -1126,27 +1126,27 @@ void ServoCalcs::collisionVelocityScaleCB(const std_msgs::msg::Float64::SharedPt
 void ServoCalcs::changeDriftDimensions(const std::shared_ptr<moveit_msgs::srv::ChangeDriftDimensions::Request> req,
                                        std::shared_ptr<moveit_msgs::srv::ChangeDriftDimensions::Response> res)
 {
-  drift_dimensions_[0] = req.get()->drift_x_translation;
-  drift_dimensions_[1] = req.get()->drift_y_translation;
-  drift_dimensions_[2] = req.get()->drift_z_translation;
-  drift_dimensions_[3] = req.get()->drift_x_rotation;
-  drift_dimensions_[4] = req.get()->drift_y_rotation;
-  drift_dimensions_[5] = req.get()->drift_z_rotation;
+  drift_dimensions_[0] = req->drift_x_translation;
+  drift_dimensions_[1] = req->drift_y_translation;
+  drift_dimensions_[2] = req->drift_z_translation;
+  drift_dimensions_[3] = req->drift_x_rotation;
+  drift_dimensions_[4] = req->drift_y_rotation;
+  drift_dimensions_[5] = req->drift_z_rotation;
 
-  res.get()->success = true;
+  res->success = true;
 }
 
 void ServoCalcs::changeControlDimensions(const std::shared_ptr<moveit_msgs::srv::ChangeControlDimensions::Request> req,
                                          std::shared_ptr<moveit_msgs::srv::ChangeControlDimensions::Response> res)
 {
-  control_dimensions_[0] = req.get()->control_x_translation;
-  control_dimensions_[1] = req.get()->control_y_translation;
-  control_dimensions_[2] = req.get()->control_z_translation;
-  control_dimensions_[3] = req.get()->control_x_rotation;
-  control_dimensions_[4] = req.get()->control_y_rotation;
-  control_dimensions_[5] = req.get()->control_z_rotation;
+  control_dimensions_[0] = req->control_x_translation;
+  control_dimensions_[1] = req->control_y_translation;
+  control_dimensions_[2] = req->control_z_translation;
+  control_dimensions_[3] = req->control_x_rotation;
+  control_dimensions_[4] = req->control_y_rotation;
+  control_dimensions_[5] = req->control_z_rotation;
 
-  res.get()->success = true;
+  res->success = true;
 }
 
 void ServoCalcs::setPaused(bool paused)

--- a/moveit_ros/moveit_servo/src/teleop_demo/joystick_servo_example.cpp
+++ b/moveit_ros/moveit_servo/src/teleop_demo/joystick_servo_example.cpp
@@ -84,8 +84,8 @@ enum Button
 
 // Some axes have offsets (e.g. the default trigger position is 1.0 not 0)
 // This will map the default values for the axes
-std::map<Axis, double> axis_defaults_ = { { LEFT_TRIGGER, 1.0 }, { RIGHT_TRIGGER, 1.0 } };
-std::map<Button, double> button_defaults_;
+std::map<Axis, double> AXIS_DEFAULTS = { { LEFT_TRIGGER, 1.0 }, { RIGHT_TRIGGER, 1.0 } };
+std::map<Button, double> BUTTON_DEFAULTS;
 
 // To change controls or setup a new controller, all you should to do is change the above enums and the follow 2
 // functions
@@ -122,8 +122,8 @@ bool convertJoyToCmd(const std::vector<float>& axes, const std::vector<int>& but
   twist->twist.linear.z = axes[RIGHT_STICK_Y];
   twist->twist.linear.y = axes[RIGHT_STICK_X];
 
-  double lin_x_right = -0.5 * (axes[RIGHT_TRIGGER] - axis_defaults_.at(RIGHT_TRIGGER));
-  double lin_x_left = 0.5 * (axes[LEFT_TRIGGER] - axis_defaults_.at(LEFT_TRIGGER));
+  double lin_x_right = -0.5 * (axes[RIGHT_TRIGGER] - AXIS_DEFAULTS.at(RIGHT_TRIGGER));
+  double lin_x_left = 0.5 * (axes[LEFT_TRIGGER] - AXIS_DEFAULTS.at(LEFT_TRIGGER));
   twist->twist.linear.x = lin_x_right + lin_x_left;
 
   twist->twist.angular.y = axes[LEFT_STICK_Y];

--- a/moveit_ros/moveit_servo/test/servo_launch_test_common.hpp
+++ b/moveit_ros/moveit_servo/test/servo_launch_test_common.hpp
@@ -82,10 +82,12 @@ public:
   ServoFixture()
     : node_(std::make_shared<rclcpp::Node>("servo_testing"))
     , executor_(std::make_shared<rclcpp::executors::SingleThreadedExecutor>())
+    , parameters_(getTestParameters())
+    , PUBLISH_HZ(2.0 / parameters_->incoming_command_timeout)
+    , PUBLISH_PERIOD(1.0 / PUBLISH_HZ)
+    , TIMEOUT_ITERATIONS(10 * PUBLISH_HZ)
+    , publish_loop_rate_(PUBLISH_HZ)
   {
-    // Read the parameters used for testing
-    parameters_ = getTestParameters();
-
     // Init ROS interfaces
     // Publishers
     pub_twist_cmd_ =
@@ -128,6 +130,10 @@ public:
       }
       RCLCPP_INFO(LOGGER, "client_servo_stop_ service not available, waiting again...");
     }
+
+    // Status sub (we need this to check that we've started / stopped)
+    sub_servo_status_ = node_->create_subscription<std_msgs::msg::Int8>(
+        "/" + parameters_->status_topic, 10, std::bind(&ServoFixture::statusCB, this, std::placeholders::_1));
     return true;
   }
 
@@ -186,13 +192,6 @@ public:
       }
       RCLCPP_INFO(LOGGER, "client_change_drift_dims_ service not available, waiting again...");
     }
-    return true;
-  }
-
-  bool setupStatusSub()
-  {
-    sub_servo_status_ = node_->create_subscription<std_msgs::msg::Int8>(
-        "/" + parameters_->status_topic, 10, std::bind(&ServoFixture::statusCB, this, std::placeholders::_1));
     return true;
   }
 
@@ -361,6 +360,70 @@ public:
     return status_seen_;
   }
 
+  bool start()
+  {
+    auto time_start = node_->now();
+    auto start_result = client_servo_start_->async_send_request(std::make_shared<std_srvs::srv::Trigger::Request>());
+    if (!start_result.get()->success)
+    {
+      RCLCPP_ERROR(LOGGER, "Error returned form service call to start servo");
+      return false;
+    }
+    RCLCPP_INFO_STREAM(LOGGER, "Wait for start servo: " << (node_->now() - time_start).seconds());
+
+    // Test that status messages start
+    time_start = node_->now();
+    auto num_statuses_start = getNumStatus();
+    size_t iterations = 0;
+    while (getNumStatus() == num_statuses_start && iterations++ < TIMEOUT_ITERATIONS)
+    {
+      publish_loop_rate_.sleep();
+    }
+
+    RCLCPP_INFO_STREAM(LOGGER, "Wait for status num increasing: " << (node_->now() - time_start).seconds());
+
+    if (iterations >= TIMEOUT_ITERATIONS)
+    {
+      RCLCPP_ERROR(LOGGER, "Timeout waiting for status num increasing");
+      return false;
+    }
+
+    return getNumStatus() > num_statuses_start;
+  }
+
+  bool stop()
+  {
+    auto time_start = node_->now();
+    auto stop_result = client_servo_stop_->async_send_request(std::make_shared<std_srvs::srv::Trigger::Request>());
+    if (!stop_result.get()->success)
+    {
+      RCLCPP_ERROR(LOGGER, "Error returned form service call to stop servo");
+      return false;
+    }
+    RCLCPP_INFO_STREAM(LOGGER, "Wait for stop servo service: " << (node_->now() - time_start).seconds());
+
+    // Test that status messages stop
+    time_start = node_->now();
+    size_t num_statuses_start = 0;
+    size_t iterations = 0;
+    do
+    {
+      num_statuses_start = getNumStatus();
+      // Wait 4x the loop rate
+      for (size_t i = 0; i < 4; ++i)
+        publish_loop_rate_.sleep();
+    } while (getNumStatus() != num_statuses_start && ++iterations < TIMEOUT_ITERATIONS);
+    RCLCPP_INFO_STREAM(LOGGER, "Wait for status to stop: " << (node_->now() - time_start).seconds());
+
+    if (iterations >= TIMEOUT_ITERATIONS)
+    {
+      RCLCPP_ERROR(LOGGER, "Timeout waiting for status num increasing");
+      return false;
+    }
+
+    return true;
+  }
+
 protected:
   rclcpp::Node::SharedPtr node_;
   rclcpp::Executor::SharedPtr executor_;
@@ -403,6 +466,11 @@ protected:
 
   bool status_seen_;
   StatusCode status_tracking_code_ = StatusCode::NO_WARNING;
+
+  const double PUBLISH_HZ;
+  const double PUBLISH_PERIOD;
+  const double TIMEOUT_ITERATIONS;
+  rclcpp::Rate publish_loop_rate_;
 
   mutable std::mutex latest_state_mutex_;
 };  // class ServoFixture

--- a/moveit_ros/moveit_servo/test/test_servo_interface.cpp
+++ b/moveit_ros/moveit_servo/test/test_servo_interface.cpp
@@ -188,8 +188,8 @@ TEST_F(ServoFixture, StaleCommandStop)
 
   // Wait the stale limit, plus a little extra
   log_time_start = node_->now();
-  const int SLEEP_TIME = 1.5 * 1000 * parameters_->incoming_command_timeout;
-  rclcpp::sleep_for(std::chrono::milliseconds(SLEEP_TIME));
+  const int sleep_time = 1.5 * 1000 * parameters_->incoming_command_timeout;
+  rclcpp::sleep_for(std::chrono::milliseconds(sleep_time));
   log_time_end = node_->now();
   RCLCPP_INFO_STREAM(LOGGER, "Wait for stopping: " << (log_time_end - log_time_start).seconds());
 
@@ -198,7 +198,7 @@ TEST_F(ServoFixture, StaleCommandStop)
   EXPECT_NE(start_position, middle_position);
 
   // Wait for a bit
-  rclcpp::sleep_for(std::chrono::milliseconds(SLEEP_TIME));
+  rclcpp::sleep_for(std::chrono::milliseconds(sleep_time));
 
   // Get the current position (should be no change)
   double end_position = getLatestTrajCommand().points[0].positions[0];

--- a/moveit_ros/moveit_servo/test/test_servo_interface.cpp
+++ b/moveit_ros/moveit_servo/test/test_servo_interface.cpp
@@ -91,7 +91,7 @@ TEST_F(ServoFixture, SendTwistStampedTest)
   auto time_start = node_->now();
 
   // Publish N messages with some time between, ensure it's less than the timeout for Servo
-  size_t num_commands = 5;
+  size_t num_commands = 30;
   resetNumCommands();
   for (size_t i = 0; i < num_commands && rclcpp::ok(); ++i)
   {
@@ -131,7 +131,7 @@ TEST_F(ServoFixture, SendJointServoTest)
   auto time_start = node_->now();
 
   // Publish N messages with some time between, ensure it's less than the timeout for Servo
-  size_t num_commands = 5;
+  size_t num_commands = 30;
   resetNumCommands();
   for (size_t i = 0; i < num_commands && rclcpp::ok(); ++i)
   {

--- a/moveit_ros/moveit_servo/test/test_servo_interface.cpp
+++ b/moveit_ros/moveit_servo/test/test_servo_interface.cpp
@@ -43,59 +43,55 @@ namespace moveit_servo
 TEST_F(ServoFixture, StartStopTest)
 {
   // Setup the start/stop clients, and the command callback
+  auto log_time_start = node_->now();
   ASSERT_TRUE(setupStartClient());
-  ASSERT_TRUE(setupStatusSub());
   ASSERT_TRUE(setupJointStateSub());
+  auto log_time_end = node_->now();
+  RCLCPP_INFO_STREAM(LOGGER, "Setup time: " << (log_time_end - log_time_start).seconds());
 
   // Wait for a joint state message to ensure fake_joint_driver is up
+  log_time_start = node_->now();
   bool got_msg = false;
   while (!got_msg)
   {
     if (getNumJointState() > 0)
       got_msg = true;
 
-    rclcpp::sleep_for(std::chrono::milliseconds(20));
+    publish_loop_rate_.sleep();
   }
   ASSERT_TRUE(got_msg);
+  log_time_end = node_->now();
+  RCLCPP_INFO_STREAM(LOGGER, "Wait for joint state message time: " << (log_time_end - log_time_start).seconds());
 
   // Try to start Servo
-  auto start_result = client_servo_start_->async_send_request(std::make_shared<std_srvs::srv::Trigger::Request>());
-  EXPECT_TRUE(start_result.get()->success);
+  ASSERT_TRUE(start());
+  EXPECT_EQ(latest_status_, moveit_servo::StatusCode::NO_WARNING);
 
-  // With servo running we should get a status that should be NO_WARNING
-  rclcpp::sleep_for(std::chrono::milliseconds(200));
-  EXPECT_TRUE(getNumStatus() > 0);
-  EXPECT_TRUE(latest_status_ == moveit_servo::StatusCode::NO_WARNING);
-
-  // Now stop servo and wait
-  auto stop_result = client_servo_stop_->async_send_request(std::make_shared<std_srvs::srv::Trigger::Request>());
-  EXPECT_TRUE(stop_result.get()->success);
-  rclcpp::sleep_for(std::chrono::seconds(1));
-  resetNumStatus();
+  // Now stop servo
+  ASSERT_TRUE(stop());
 
   // Restart and recheck Servo
-  start_result = client_servo_start_->async_send_request(std::make_shared<std_srvs::srv::Trigger::Request>());
-  EXPECT_TRUE(start_result.get()->success);
-  rclcpp::sleep_for(std::chrono::milliseconds(200));
-  EXPECT_TRUE(getNumStatus() > 0);
-  EXPECT_TRUE(latest_status_ == moveit_servo::StatusCode::NO_WARNING);
+  ASSERT_TRUE(start());
+  EXPECT_EQ(latest_status_, moveit_servo::StatusCode::NO_WARNING);
 }
 
 TEST_F(ServoFixture, SendTwistStampedTest)
 {
+  auto log_time_start = node_->now();
   ASSERT_TRUE(setupStartClient());
   ASSERT_TRUE(setupCommandSub(parameters_->command_out_type));
+  auto log_time_end = node_->now();
+  RCLCPP_INFO_STREAM(LOGGER, "Setup time: " << (log_time_end - log_time_start).seconds());
 
   // Start Servo
-  auto start_result = client_servo_start_->async_send_request(std::make_shared<std_srvs::srv::Trigger::Request>());
-  ASSERT_TRUE(start_result.get()->success);
+  ASSERT_TRUE(start());
+  EXPECT_EQ(latest_status_, moveit_servo::StatusCode::NO_WARNING);
 
   // We want to count the number of commands Servo publishes, we need timing
   auto time_start = node_->now();
 
   // Publish N messages with some time between, ensure it's less than the timeout for Servo
-  size_t num_commands = 30;
-  rclcpp::Rate loop_rate(2 / parameters_->incoming_command_timeout);
+  size_t num_commands = 5;
   resetNumCommands();
   for (size_t i = 0; i < num_commands && rclcpp::ok(); ++i)
   {
@@ -104,7 +100,7 @@ TEST_F(ServoFixture, SendTwistStampedTest)
     msg->twist.linear.x = 0.1;
     msg->twist.angular.z = 0.5;
     pub_twist_cmd_->publish(std::move(msg));
-    loop_rate.sleep();
+    publish_loop_rate_.sleep();
   }
 
   // Capture the time and number of recieved messages
@@ -113,6 +109,7 @@ TEST_F(ServoFixture, SendTwistStampedTest)
 
   // Compare actual number recieved to expected number
   auto num_expected = (time_end - time_start).seconds() / parameters_->publish_period;
+  RCLCPP_INFO_STREAM(LOGGER, "Wait publish messages: " << (time_end - time_start).seconds());
 
   EXPECT_GT(num_recieved, 0.5 * num_expected);
   EXPECT_LT(num_recieved, 1.5 * num_expected);
@@ -120,19 +117,21 @@ TEST_F(ServoFixture, SendTwistStampedTest)
 
 TEST_F(ServoFixture, SendJointServoTest)
 {
+  auto log_time_start = node_->now();
   ASSERT_TRUE(setupStartClient());
   ASSERT_TRUE(setupCommandSub(parameters_->command_out_type));
+  auto log_time_end = node_->now();
+  RCLCPP_INFO_STREAM(LOGGER, "Setup time: " << (log_time_end - log_time_start).seconds());
 
   // Start Servo
-  auto start_result = client_servo_start_->async_send_request(std::make_shared<std_srvs::srv::Trigger::Request>());
-  ASSERT_TRUE(start_result.get()->success);
+  ASSERT_TRUE(start());
+  EXPECT_EQ(latest_status_, moveit_servo::StatusCode::NO_WARNING);
 
   // We want to count the number of commands Servo publishes, we need timing
   auto time_start = node_->now();
 
   // Publish N messages with some time between, ensure it's less than the timeout for Servo
-  size_t num_commands = 30;
-  rclcpp::Rate loop_rate(2 / parameters_->incoming_command_timeout);
+  size_t num_commands = 5;
   resetNumCommands();
   for (size_t i = 0; i < num_commands && rclcpp::ok(); ++i)
   {
@@ -142,7 +141,7 @@ TEST_F(ServoFixture, SendJointServoTest)
     msg->joint_names.push_back("panda_joint1");
     msg->velocities.push_back(0.1);
     pub_joint_cmd_->publish(std::move(msg));
-    loop_rate.sleep();
+    publish_loop_rate_.sleep();
   }
 
   // Capture the time and number of recieved messages
@@ -151,6 +150,8 @@ TEST_F(ServoFixture, SendJointServoTest)
 
   // Compare actual number recieved to expected number
   auto num_expected = (time_end - time_start).seconds() / parameters_->publish_period;
+  log_time_end = node_->now();
+  RCLCPP_INFO_STREAM(LOGGER, "Wait publish messages: " << (time_end - time_start).seconds());
 
   EXPECT_GT(num_recieved, 0.5 * num_expected);
   EXPECT_LT(num_recieved, 1.5 * num_expected);
@@ -158,22 +159,23 @@ TEST_F(ServoFixture, SendJointServoTest)
 
 TEST_F(ServoFixture, StaleCommandStop)
 {
+  auto log_time_start = node_->now();
   ASSERT_TRUE(setupStartClient());
   ASSERT_TRUE(setupCommandSub(parameters_->command_out_type));
+  auto log_time_end = node_->now();
+  RCLCPP_INFO_STREAM(LOGGER, "Setup time: " << (log_time_end - log_time_start).seconds());
 
   // Start Servo
-  auto start_result = client_servo_start_->async_send_request(std::make_shared<std_srvs::srv::Trigger::Request>());
-  ASSERT_TRUE(start_result.get()->success);
+  log_time_start = node_->now();
+  ASSERT_TRUE(start());
+  EXPECT_EQ(latest_status_, moveit_servo::StatusCode::NO_WARNING);
 
   // Setup the message to publish (only once)
+  log_time_start = node_->now();
   auto msg = std::make_unique<control_msgs::msg::JointJog>();
   msg->joint_names.push_back("panda_joint1");
   msg->header.frame_id = "panda_link3";
-  msg->velocities.push_back(0.1);
-
-  // Wait the stale limit, plus a little extra
-  const int sleep_time = 5 * 1000 * parameters_->incoming_command_timeout;
-  rclcpp::sleep_for(std::chrono::milliseconds(sleep_time));
+  msg->velocities.push_back(0.5);
 
   // Get current position
   double start_position = getLatestTrajCommand().points[0].positions[0];
@@ -181,16 +183,22 @@ TEST_F(ServoFixture, StaleCommandStop)
   // Publish once
   msg->header.stamp = node_->now();
   pub_joint_cmd_->publish(std::move(msg));
+  log_time_end = node_->now();
+  RCLCPP_INFO_STREAM(LOGGER, "Wait for send one joint cmd: " << (log_time_end - log_time_start).seconds());
 
   // Wait the stale limit, plus a little extra
-  rclcpp::sleep_for(std::chrono::milliseconds(sleep_time));
+  log_time_start = node_->now();
+  const int SLEEP_TIME = 1.5 * 1000 * parameters_->incoming_command_timeout;
+  rclcpp::sleep_for(std::chrono::milliseconds(SLEEP_TIME));
+  log_time_end = node_->now();
+  RCLCPP_INFO_STREAM(LOGGER, "Wait for stopping: " << (log_time_end - log_time_start).seconds());
 
   // Get the new current position (should be different than first)
   double middle_position = getLatestTrajCommand().points[0].positions[0];
   EXPECT_NE(start_position, middle_position);
 
-  // Wait the stale limit
-  rclcpp::sleep_for(std::chrono::milliseconds(sleep_time));
+  // Wait for a bit
+  rclcpp::sleep_for(std::chrono::milliseconds(SLEEP_TIME));
 
   // Get the current position (should be no change)
   double end_position = getLatestTrajCommand().points[0].positions[0];

--- a/moveit_ros/moveit_servo/test/test_servo_parameters_node.cpp
+++ b/moveit_ros/moveit_servo/test/test_servo_parameters_node.cpp
@@ -44,22 +44,22 @@
 #include <std_srvs/srv/trigger.hpp>
 #include "test_parameter_struct.hpp"
 
-bool load_params_success_ = false;
-bool expected_load_params_success_, got_expected_, equals_expected_;
+bool LOAD_PARAMS_SUCCESS = false;
+bool EXPECTED_LOAD_PARAMS_SUCCESS, GOT_EXPECTED, EQUALS_EXPECTED;
 
-void loadResultCB(const std::shared_ptr<std_srvs::srv::Trigger::Request>,
+void loadResultCB(const std::shared_ptr<std_srvs::srv::Trigger::Request> /*unused*/,
                   std::shared_ptr<std_srvs::srv::Trigger::Response> response)
 {
   // To pass (return true here), we need:
   // 1) To have gotten the parameter telling us if we should have success loading parameters
   // 2) Our success/fail loading parameters should match the expected
-  response->success = (got_expected_ && load_params_success_ == expected_load_params_success_);
+  response->success = (GOT_EXPECTED && LOAD_PARAMS_SUCCESS == EXPECTED_LOAD_PARAMS_SUCCESS);
 }
 
-void expectedResultCB(const std::shared_ptr<std_srvs::srv::Trigger::Request>,
+void expectedResultCB(const std::shared_ptr<std_srvs::srv::Trigger::Request> /*unused*/,
                       std::shared_ptr<std_srvs::srv::Trigger::Response> response)
 {
-  response->success = equals_expected_;
+  response->success = EQUALS_EXPECTED;
 }
 
 int main(int argc, char** argv)
@@ -72,13 +72,13 @@ int main(int argc, char** argv)
   // We need to know whether or not to expect valid parameter loading
   // This param passed alongside 'servo_params' in launch file
   node->declare_parameter<bool>("expect_valid_params", true);
-  got_expected_ = node->get_parameter("expect_valid_params", expected_load_params_success_);
-  RCLCPP_INFO_STREAM(LOGGER, "Got expect_valid_params? : " << got_expected_
-                                                           << ", value = " << expected_load_params_success_);
+  GOT_EXPECTED = node->get_parameter("expect_valid_params", EXPECTED_LOAD_PARAMS_SUCCESS);
+  RCLCPP_INFO_STREAM(LOGGER, "Got expect_valid_params? : " << GOT_EXPECTED
+                                                           << ", value = " << EXPECTED_LOAD_PARAMS_SUCCESS);
 
   // Create and try to load the parameters
   auto servo_parameters = std::make_shared<moveit_servo::ServoParameters>();
-  load_params_success_ = moveit_servo::readParameters(servo_parameters, node, LOGGER);
+  LOAD_PARAMS_SUCCESS = moveit_servo::readParameters(servo_parameters, node, LOGGER);
 
   // Offer a service to report the success/fail of the loading
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr loading_service =
@@ -86,7 +86,7 @@ int main(int argc, char** argv)
 
   // Check to see if the parameters we grabbed equal the expected ones for testing
   moveit_servo::ServoParametersPtr test_params = getTestParameters();
-  equals_expected_ = (*test_params == *servo_parameters);
+  EQUALS_EXPECTED = (*test_params == *servo_parameters);
 
   // Offer a service to report if the loading matches the test parameters
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr equal_expected_service =

--- a/moveit_ros/moveit_servo/test/unit_test_servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/test/unit_test_servo_calcs.cpp
@@ -305,9 +305,9 @@ TEST_F(ServoCalcsTestFixture, TestSuddenHalt)
   // Let's start with an empty trajectory
   trajectory_msgs::msg::JointTrajectory msg;
   servo_calcs_->suddenHalt(msg);
-  EXPECT_TRUE(msg.points.size() == 1);
-  EXPECT_TRUE(msg.points[0].positions.size() == 3);
-  EXPECT_TRUE(msg.points[0].velocities.size() == 3);
+  EXPECT_EQ(msg.points.size(), 1);
+  EXPECT_EQ(msg.points[0].positions.size(), 3);
+  EXPECT_EQ(msg.points[0].velocities.size(), 3);
   EXPECT_EQ(msg.points[0].positions[2], 3.0);
   EXPECT_EQ(msg.points[0].velocities[2], 0.0);
 
@@ -506,10 +506,10 @@ TEST_F(ServoCalcsTestFixture, TestComposeOutputMsg)
   EXPECT_EQ(traj.joint_names[0], "some_joint");
 
   // Check the trajectory info
-  EXPECT_TRUE(traj.points.size() == 1);
-  EXPECT_TRUE(traj.points[0].positions.size() == 1);  // Set to input length
-  EXPECT_TRUE(traj.points[0].velocities.size() == 1);
-  EXPECT_TRUE(traj.points[0].accelerations.size() == 7);  // Set to num joints
+  EXPECT_EQ(traj.points.size(), 1);
+  EXPECT_EQ(traj.points[0].positions.size(), 1);  // Set to input length
+  EXPECT_EQ(traj.points[0].velocities.size(), 1);
+  EXPECT_EQ(traj.points[0].accelerations.size(), 7);  // Set to num joints
   EXPECT_EQ(traj.points[0].positions[0], 1.0);
   EXPECT_EQ(traj.points[0].velocities[0], 2.0);
   EXPECT_EQ(traj.points[0].accelerations[0], 0.0);

--- a/moveit_ros/moveit_servo/test/unit_test_servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/test/unit_test_servo_calcs.cpp
@@ -305,9 +305,9 @@ TEST_F(ServoCalcsTestFixture, TestSuddenHalt)
   // Let's start with an empty trajectory
   trajectory_msgs::msg::JointTrajectory msg;
   servo_calcs_->suddenHalt(msg);
-  EXPECT_EQ(msg.points.size(), 1);
-  EXPECT_EQ(msg.points[0].positions.size(), 3);
-  EXPECT_EQ(msg.points[0].velocities.size(), 3);
+  EXPECT_EQ(msg.points.size(), 1UL);
+  EXPECT_EQ(msg.points[0].positions.size(), 3UL);
+  EXPECT_EQ(msg.points[0].velocities.size(), 3UL);
   EXPECT_EQ(msg.points[0].positions[2], 3.0);
   EXPECT_EQ(msg.points[0].velocities[2], 0.0);
 
@@ -506,10 +506,10 @@ TEST_F(ServoCalcsTestFixture, TestComposeOutputMsg)
   EXPECT_EQ(traj.joint_names[0], "some_joint");
 
   // Check the trajectory info
-  EXPECT_EQ(traj.points.size(), 1);
-  EXPECT_EQ(traj.points[0].positions.size(), 1);  // Set to input length
-  EXPECT_EQ(traj.points[0].velocities.size(), 1);
-  EXPECT_EQ(traj.points[0].accelerations.size(), 7);  // Set to num joints
+  EXPECT_EQ(traj.points.size(), 1UL);
+  EXPECT_EQ(traj.points[0].positions.size(), 1UL);  // Set to input length
+  EXPECT_EQ(traj.points[0].velocities.size(), 1UL);
+  EXPECT_EQ(traj.points[0].accelerations.size(), 7UL);  // Set to num joints
   EXPECT_EQ(traj.points[0].positions[0], 1.0);
   EXPECT_EQ(traj.points[0].velocities[0], 2.0);
   EXPECT_EQ(traj.points[0].accelerations[0], 0.0);

--- a/moveit_ros/moveit_servo/test/unit_test_servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/test/unit_test_servo_calcs.cpp
@@ -101,7 +101,7 @@ sensor_msgs::msg::JointState ServoCalcsTestFixture::getJointState(std::vector<do
   std::vector<double> effort;
   effort.assign(9, 0);
 
-  msg.name = panda_joint_names_;
+  msg.name = PANDA_JOINT_NAMES;
   msg.position = pos;
   msg.velocity = vel;
   msg.effort = effort;
@@ -465,7 +465,7 @@ TEST_F(ServoCalcsTestFixture, TestScaleJointCommand)
 {
   // Get a JointJog msg to test
   control_msgs::msg::JointJog msg;
-  msg.joint_names = panda_joint_names_;
+  msg.joint_names = PANDA_JOINT_NAMES;
   std::vector<double> vel{ 0, 0, 1, 1, 1, 1, 1, 1, 1 };
   msg.velocities = vel;
 

--- a/moveit_ros/moveit_servo/test/unit_test_servo_calcs.hpp
+++ b/moveit_ros/moveit_servo/test/unit_test_servo_calcs.hpp
@@ -44,9 +44,9 @@
 #include <gtest/gtest.h>
 #include <moveit_servo/servo_calcs.h>
 
-const std::vector<std::string> panda_joint_names_{ "panda_finger_joint1", "panda_finger_joint2", "panda_joint1",
-                                                   "panda_joint2",        "panda_joint3",        "panda_joint4",
-                                                   "panda_joint5",        "panda_joint6",        "panda_joint7" };
+const std::vector<std::string> PANDA_JOINT_NAMES{ "panda_finger_joint1", "panda_finger_joint2", "panda_joint1",
+                                                  "panda_joint2",        "panda_joint3",        "panda_joint4",
+                                                  "panda_joint5",        "panda_joint6",        "panda_joint7" };
 
 // subclassing and friending so we can access member varibles
 class FriendServoCalcs : public moveit_servo::ServoCalcs
@@ -74,9 +74,9 @@ class ServoCalcsTestFixture : public ::testing::Test
 {
 public:
   ServoCalcsTestFixture();
-  ~ServoCalcsTestFixture(){};
+  ~ServoCalcsTestFixture() override = default;
 
-  void SetUpStateController();
+  void setUpStateController();
 
 protected:
   rclcpp::Node::SharedPtr node_;


### PR DESCRIPTION
### Description

Here are some small changes to speed up testing and hopefully we can get under the 60s timeout on travis.  These changes made so locally I was able to run the tests in ~8s vs the ~18s it took before.

Most of what I did was change places where we waited for a fixed amount of time to instead wait until the condition was fulfilled.  I also added a bunch of instrumentation around how long different steps take.  Part of the goal of that is to see if there is some specific step that is taking a long time in the travis logs and if there is anything we can do about it.